### PR TITLE
Export private fields in SimpleElement, CompoundElement and SharedElement

### DIFF
--- a/kml.go
+++ b/kml.go
@@ -48,7 +48,7 @@ type CompoundElement struct {
 // A SharedElement is an element with an id.
 type SharedElement struct {
 	CompoundElement
-	Id string
+	ID string
 }
 
 // MarshalXML marshals se to e. start is ignored.
@@ -132,7 +132,7 @@ func (ce *CompoundElement) WriteIndent(w io.Writer, prefix, indent string) error
 
 // URL returns se's URL.
 func (se *SharedElement) URL() string {
-	return "#" + se.Id
+	return "#" + se.ID
 }
 
 func formatBool(value bool) string {
@@ -251,6 +251,6 @@ func newSharedE(name, id string, children []Element) *SharedElement {
 			},
 			Children: children,
 		},
-		Id: id,
+		ID: id,
 	}
 }

--- a/kml.go
+++ b/kml.go
@@ -130,19 +130,9 @@ func (ce *CompoundElement) WriteIndent(w io.Writer, prefix, indent string) error
 	return write(w, prefix, indent, ce)
 }
 
-// ID returns se's id.
-func (se *SharedElement) ID() string {
-	return se.Id
-}
-
-// SetID sets se's id.
-func (se *SharedElement) SetID(id string) {
-	se.Id = id
-}
-
 // URL returns se's URL.
 func (se *SharedElement) URL() string {
-	return "#" + se.ID()
+	return "#" + se.Id
 }
 
 func formatBool(value bool) string {

--- a/kml.go
+++ b/kml.go
@@ -36,54 +36,54 @@ type Element interface {
 // A SimpleElement is an Element with a single value.
 type SimpleElement struct {
 	xml.StartElement
-	value string
+	Value string
 }
 
 // A CompoundElement is an Element with children.
 type CompoundElement struct {
 	xml.StartElement
-	children []Element
+	Children []Element
 }
 
 // A SharedElement is an element with an id.
 type SharedElement struct {
 	CompoundElement
-	id string
+	Id string
 }
 
 // MarshalXML marshals se to e. start is ignored.
 func (se *SimpleElement) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	return e.EncodeElement(xml.CharData(se.value), se.StartElement)
+	return e.EncodeElement(xml.CharData(se.Value), se.StartElement)
 }
 
 // SetBool sets se's value from a bool.
 func (se *SimpleElement) SetBool(value bool) {
-	se.value = formatBool(value)
+	se.Value = formatBool(value)
 }
 
 // SetColor sets se's value from a color.Color.
 func (se *SimpleElement) SetColor(value color.Color) {
-	se.value = formatColor(value)
+	se.Value = formatColor(value)
 }
 
 // SetFloat set se's value from a float64.
 func (se *SimpleElement) SetFloat(value float64) {
-	se.value = formatFloat(value)
+	se.Value = formatFloat(value)
 }
 
 // SetInt sets se's value from an int.
 func (se *SimpleElement) SetInt(value int) {
-	se.value = formatInt(value)
+	se.Value = formatInt(value)
 }
 
 // SetString sets se's value from a string.
 func (se *SimpleElement) SetString(value string) {
-	se.value = value
+	se.Value = value
 }
 
 // SetTime sets se'ss value from a time.Time.
 func (se *SimpleElement) SetTime(value time.Time) {
-	se.value = formatTime(value)
+	se.Value = formatTime(value)
 }
 
 // Write writes an XML header and se to w.
@@ -98,13 +98,13 @@ func (se *SimpleElement) WriteIndent(w io.Writer, prefix, indent string) error {
 
 // Add adds children to ce.
 func (ce *CompoundElement) Add(children ...Element) *CompoundElement {
-	ce.children = append(ce.children, children...)
+	ce.Children = append(ce.Children, children...)
 	return ce
 }
 
 // SetChildren sets ce's children.
 func (ce *CompoundElement) SetChildren(children []Element) {
-	ce.children = children
+	ce.Children = children
 }
 
 // MarshalXML marshals ce to e. start is ignored.
@@ -112,7 +112,7 @@ func (ce *CompoundElement) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 	if err := e.EncodeToken(ce.StartElement); err != nil {
 		return err
 	}
-	for _, c := range ce.children {
+	for _, c := range ce.Children {
 		if err := e.EncodeElement(c, ce.StartElement); err != nil {
 			return err
 		}
@@ -132,12 +132,12 @@ func (ce *CompoundElement) WriteIndent(w io.Writer, prefix, indent string) error
 
 // ID returns se's id.
 func (se *SharedElement) ID() string {
-	return se.id
+	return se.Id
 }
 
 // SetID sets se's id.
 func (se *SharedElement) SetID(id string) {
-	se.id = id
+	se.Id = id
 }
 
 // URL returns se's URL.
@@ -181,35 +181,35 @@ func write(w io.Writer, prefix, indent string, m xml.Marshaler) error {
 func newSEBool(name string, value bool) *SimpleElement {
 	return &SimpleElement{
 		StartElement: xml.StartElement{Name: xml.Name{Local: name}},
-		value:        formatBool(value),
+		Value:        formatBool(value),
 	}
 }
 
 func newSEColor(name string, value color.Color) *SimpleElement {
 	return &SimpleElement{
 		StartElement: xml.StartElement{Name: xml.Name{Local: name}},
-		value:        formatColor(value),
+		Value:        formatColor(value),
 	}
 }
 
 func newSEElement(name string, value Element) *CompoundElement {
 	return &CompoundElement{
 		StartElement: xml.StartElement{Name: xml.Name{Local: name}},
-		children:     []Element{value},
+		Children:     []Element{value},
 	}
 }
 
 func newSEFloat(name string, value float64) *SimpleElement {
 	return &SimpleElement{
 		StartElement: xml.StartElement{Name: xml.Name{Local: name}},
-		value:        formatFloat(value),
+		Value:        formatFloat(value),
 	}
 }
 
 func newSEInt(name string, value int) *SimpleElement {
 	return &SimpleElement{
 		StartElement: xml.StartElement{Name: xml.Name{Local: name}},
-		value:        formatInt(value),
+		Value:        formatInt(value),
 	}
 }
 
@@ -230,21 +230,21 @@ func newSEVec2(name string, value Vec2) *SimpleElement {
 func newSEString(name, value string) *SimpleElement {
 	return &SimpleElement{
 		StartElement: xml.StartElement{Name: xml.Name{Local: name}},
-		value:        value,
+		Value:        value,
 	}
 }
 
 func newSETime(name string, value time.Time) *SimpleElement {
 	return &SimpleElement{
 		StartElement: xml.StartElement{Name: xml.Name{Local: name}},
-		value:        formatTime(value),
+		Value:        formatTime(value),
 	}
 }
 
 func newCE(name string, children []Element) *CompoundElement {
 	return &CompoundElement{
 		StartElement: xml.StartElement{Name: xml.Name{Local: name}},
-		children:     children,
+		Children:     children,
 	}
 }
 
@@ -259,8 +259,8 @@ func newSharedE(name, id string, children []Element) *SharedElement {
 				Name: xml.Name{Local: name},
 				Attr: attr,
 			},
-			children: children,
+			Children: children,
 		},
-		id: id,
+		Id: id,
 	}
 }

--- a/kml22gx.go
+++ b/kml22gx.go
@@ -29,7 +29,7 @@ func GxAngles(value GxAngle) *SimpleElement {
 		StartElement: xml.StartElement{
 			Name: xml.Name{Local: "gx:angles"},
 		},
-		value: strconv.FormatFloat(value.Heading, 'f', -1, 64) + " " +
+		Value: strconv.FormatFloat(value.Heading, 'f', -1, 64) + " " +
 			strconv.FormatFloat(value.Tilt, 'f', -1, 64) + " " +
 			strconv.FormatFloat(value.Roll, 'f', -1, 64),
 	}
@@ -41,7 +41,7 @@ func GxCoord(value Coordinate) *SimpleElement {
 		StartElement: xml.StartElement{
 			Name: xml.Name{Local: "gx:coord"},
 		},
-		value: strconv.FormatFloat(value.Lon, 'f', -1, 64) + " " +
+		Value: strconv.FormatFloat(value.Lon, 'f', -1, 64) + " " +
 			strconv.FormatFloat(value.Lat, 'f', -1, 64) + " " +
 			strconv.FormatFloat(value.Alt, 'f', -1, 64),
 	}

--- a/ogckml22.go
+++ b/ogckml22.go
@@ -186,7 +186,7 @@ func Schema(id, name string, children ...Element) *SharedElement {
 			},
 			Children: children,
 		},
-		Id: id,
+		ID: id,
 	}
 }
 

--- a/ogckml22.go
+++ b/ogckml22.go
@@ -169,7 +169,7 @@ func LinkSnippet(maxLines int, value string) *SimpleElement {
 				{Name: xml.Name{Local: "maxLines"}, Value: strconv.Itoa(maxLines)},
 			},
 		},
-		value: value,
+		Value: value,
 	}
 }
 
@@ -184,9 +184,9 @@ func Schema(id, name string, children ...Element) *SharedElement {
 					{Name: xml.Name{Local: "name"}, Value: name},
 				},
 			},
-			children: children,
+			Children: children,
 		},
-		id: id,
+		Id: id,
 	}
 }
 
@@ -199,7 +199,7 @@ func SchemaData(schemaURL string, children ...Element) *CompoundElement {
 				{Name: xml.Name{Local: "schemaUrl"}, Value: schemaURL},
 			},
 		},
-		children: children,
+		Children: children,
 	}
 }
 
@@ -222,7 +222,7 @@ func SimpleData(name, value string) *SimpleElement {
 				{Name: xml.Name{Local: "name"}, Value: name},
 			},
 		},
-		value: value,
+		Value: value,
 	}
 }
 
@@ -236,7 +236,7 @@ func SimpleField(name, _type string, children ...Element) *CompoundElement {
 				{Name: xml.Name{Local: "type"}, Value: _type},
 			},
 		},
-		children: children,
+		Children: children,
 	}
 }
 
@@ -246,6 +246,6 @@ func KML(child Element) *CompoundElement {
 		StartElement: xml.StartElement{
 			Name: xml.Name{Space: Namespace, Local: "kml"},
 		},
-		children: []Element{child},
+		Children: []Element{child},
 	}
 }


### PR DESCRIPTION
Export private fields to create custom elements 

```go
customElement := &kml.CompoundElement{
    StartElement: xml.StartElement{Name: xml.Name{Local: "Folder"}, Attr: []xml.Attr{{Name: xml.Name{Local: "id"}, Value: "myCustomID"}}},
    Children: []kml.Element{
        kml.Name("My custom folder name"),
    },
}

k := kml.KML(
    customElement,
)

if err := k.WriteIndent(os.Stdout, "", "  "); err != nil {
    log.Fatal(err)
}
```

Output
```
<?xml version="1.0" encoding="UTF-8"?>
<kml xmlns="http://www.opengis.net/kml/2.2">
  <Folder id="myCustomID">
    <name>My custom folder name</name>
  </Folder>
</kml>
```